### PR TITLE
Allow adding additional roles to a server

### DIFF
--- a/app/routes/servers.js
+++ b/app/routes/servers.js
@@ -543,21 +543,25 @@ function addServerToDatabase(serverHostname, serverUsername, serverPassword, ser
 		if (err)
 			callback(1);
 		if (serverRole !== '' && typeof serverRole != 'undefined') {
-			serverId = rows.insertId;
-			database.query('SELECT * FROM roles JOIN servers on roles.fk_server = servers.id WHERE servers.hostname=\'' + serverHostname + '\'', function (err, rows, field) {
-				if(err){
-					console.log(err);
+			database.query('SELECT * FROM servers WHERE hostname =\'' + serverHostname + '\'', function (err, rows, field) {
+				if (err)
 					callback(1);
-				}
-				if(rows.length === 0) {
-					database.query('INSERT INTO roles VALUES(null,\'' + serverRole + '\',\'' + serverId + '\')', function (err, rows, field) {
-						if (err)
-							callback(1);
+				serverId = rows[0].id;
+				database.query('SELECT * FROM roles JOIN servers on roles.fk_server = servers.id WHERE servers.hostname=\'' + serverHostname + '\' AND roles.name=\'' + serverRole + '\'', function (err, rows, field) {
+					if(err){
+						console.log(err);
+						callback(1);
+					}
+					if(rows.length === 0) {
+						database.query('INSERT INTO roles VALUES(null,\'' + serverRole + '\',\'' + serverId + '\')', function (err, rows, field) {
+							if (err)
+								callback(1);
+							callback(0);
+						});
+					}
+					else
 						callback(0);
-					});
-				}
-				else
-					callback(0);
+				});
 			});
 		}
 	});


### PR DESCRIPTION
This change will allow a server to have several roles. Just go through the normal procedure with adding roles via the task list however you can now use the same hostname for several roles. 

Needs the changes from the module at: https://github.com/atomia/puppet-atomia/pull/122

In response to Issue #25

Next step should be to define a template for a minimal installation that pre merge roles to make the process easier.