### PR TITLE
Fix windows roles reading from puppet

### DIFF
--- a/app/routes/roles.js
+++ b/app/routes/roles.js
@@ -1,28 +1,32 @@
 var express = require('express');
 var router = express.Router();
 router.get('/role/:role', function (req, res, next) {
-	var roleName = req.params.role;
-	console.log(roleName);
-	database.query('SELECT * FROM roles JOIN servers on fk_server = servers.id WHERE name = \'' + roleName + '\' ORDER by roles.id DESC LIMIT 1', function (err, rows, field) {
-		if (err)
-			throw err;
-		res.json({ role: rows });
-	});
+        var roleName = req.params.role;
+        console.log(roleName);
+        database.query('SELECT * FROM roles JOIN servers on fk_server = servers.id WHERE name = \'' + roleName + '\' ORDER by roles.id DESC LIMIT 1', function (err, rows, field) {
+                if (err)
+                        throw err;
+                res.json({ role: rows });
+        });
 });
 router.get('/:hostname/:json?', function (req, res, next) {
-	var hostname = req.params.hostname;
-	database.query('SELECT * FROM roles JOIN servers ON roles.fk_server = servers.id WHERE servers.hostname = \'' + hostname + '\'', function (err, rows, field) {
-		if (err)
-			throw err;
-		if (req.params.json) {
-			data = [];
-			for (var i = 0; i < rows.length; i++) {
-				data.push(rows[i].name);
-			}
-			res.json({ roles: data });
-		} else {
-			res.render('roles/hostname', { keys: rows });
-		}
-	});
+        var hostname = req.params.hostname;
+        //fix windows hostname change
+        var firstpart = req.params.hostname.split('.')[0];
+        var query = 'SELECT * FROM roles JOIN servers ON roles.fk_server = servers.id WHERE servers.hostname LIKE \'' + firstpart + '%\'';
+        console.log(query);
+        database.query(query, function (err, rows, field) {
+                if (err)
+                        throw err;
+                if (req.params.json) {
+                        data = [];
+                        for (var i = 0; i < rows.length; i++) {
+                                data.push(rows[i].name);
+                        }
+                        res.json({ roles: data });
+                } else {
+                        res.render('roles/hostname', { keys: rows });
+                }
+        });
 });
 module.exports = router;


### PR DESCRIPTION
Puppet agent needs to read the role and set it on Windows servers before
being able to provision the node. In order to know the role to which the
server is assigned it needs to contact puppetmaster-gui server in the
roles route. The previous implementation just searched for the hostname
directly in the database. Sometimes for windows server if the domain is
different puppet may think that the hostname of the machine is not the
same as the one written in the hiera database trough puppetmaster-gui.

Consider the example:
 - Resolvable hostname: public-apps.example.com
 - Win server hostname: public-apps
 - Hostname wit domain: public-apps.example.local

All these three examples contain one common part and that is the string
that represents the machine name "public-apps". The fix just strips
everything after the dot in the hostname and searches by the first part
of the string. Since the server names must be unique then this will work
in any mentioned case.

Resolves PROD-1927.