### PR TITLE
Fix absolute path for config file

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -21,7 +21,7 @@ var wizard = require('./routes/wizard');
 var config = require('./routes/config');
 var roles = require('./routes/roles');
 var middleWareMenu = require('./middleware/menu');
-nconf.file({ file: 'config.json' });
+nconf.file({ file: '/opt/puppetmaster-gui/app/config.json' });
 dbConf = nconf.get('database');
 
 var db_config = {


### PR DESCRIPTION
Puppetmaster-gui service would not start because it could not load
configuration file needed for logging into the database.

After replacing the relative path with absolute problem is solved.

Resolves PROD-1933.