### PR TITLE
Upgrade morgan nodejs package

### DIFF
--- a/app/npm-shrinkwrap.json
+++ b/app/npm-shrinkwrap.json
@@ -38,9 +38,9 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
     },
     "ansi-to-html": {
-      "version": "0.6.9",
-      "from": "ansi-to-html@>=0.6.9 <0.7.0",
-      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.9.tgz"
+      "version": "0.6.11",
+      "from": "ansi-to-html@0.6.11",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.11.tgz"
     },
     "argparse": {
       "version": "1.0.10",
@@ -93,9 +93,9 @@
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz"
     },
     "basic-auth": {
-      "version": "1.0.4",
-      "from": "basic-auth@>=1.0.3 <1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz"
+      "version": "2.0.1",
+      "from": "basic-auth@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz"
     },
     "better-assert": {
       "version": "1.0.2",
@@ -103,9 +103,9 @@
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz"
     },
     "bignumber.js": {
-      "version": "4.1.0",
-      "from": "bignumber.js@4.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz"
+      "version": "7.2.1",
+      "from": "bignumber.js@7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz"
     },
     "blob": {
       "version": "0.0.4",
@@ -113,9 +113,26 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
     },
     "body-parser": {
-      "version": "1.18.3",
-      "from": "body-parser@>=1.13.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz"
+      "version": "1.19.0",
+      "from": "body-parser@1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "dependencies": {
+        "mime-db": {
+          "version": "1.40.0",
+          "from": "mime-db@1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.24",
+          "from": "mime-types@>=2.1.24 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz"
+        },
+        "type-is": {
+          "version": "1.6.18",
+          "from": "type-is@>=1.6.17 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -123,9 +140,9 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
     },
     "bytes": {
-      "version": "3.0.0",
-      "from": "bytes@3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
+      "version": "3.1.0",
+      "from": "bytes@3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz"
     },
     "callsite": {
       "version": "1.0.0",
@@ -222,9 +239,9 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
     },
     "cookie-parser": {
-      "version": "1.4.3",
-      "from": "cookie-parser@>=1.4.3 <1.5.0",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz"
+      "version": "1.4.4",
+      "from": "cookie-parser@1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz"
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -432,14 +449,14 @@
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
     },
     "http-errors": {
-      "version": "1.6.3",
-      "from": "http-errors@>=1.6.3 <1.7.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
+      "version": "1.7.2",
+      "from": "http-errors@1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz"
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "from": "iconv-lite@0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz"
+      "version": "0.4.24",
+      "from": "iconv-lite@0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
     },
     "indexof": {
       "version": "0.0.1",
@@ -577,26 +594,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "morgan": {
-      "version": "1.6.1",
-      "from": "morgan@>=1.6.1 <1.7.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "depd": {
-          "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        }
-      }
+      "version": "1.9.1",
+      "from": "morgan@1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz"
     },
     "ms": {
       "version": "2.0.0",
@@ -604,9 +604,9 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
     },
     "mysql": {
-      "version": "2.16.0",
-      "from": "mysql@>=2.9.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.16.0.tgz"
+      "version": "2.17.1",
+      "from": "mysql@2.17.1",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.17.1.tgz"
     },
     "nconf": {
       "version": "0.8.5",
@@ -661,9 +661,9 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "on-headers": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "on-headers@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz"
     },
     "once": {
       "version": "1.4.0",
@@ -721,9 +721,9 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
     },
     "process-nextick-args": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "from": "process-nextick-args@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
     },
     "promise": {
       "version": "6.1.0",
@@ -741,9 +741,9 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "qs": {
-      "version": "6.5.2",
-      "from": "qs@6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
+      "version": "6.7.0",
+      "from": "qs@6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz"
     },
     "range-parser": {
       "version": "1.0.3",
@@ -751,9 +751,9 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
     },
     "raw-body": {
-      "version": "2.3.3",
-      "from": "raw-body@2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz"
+      "version": "2.4.0",
+      "from": "raw-body@2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz"
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -867,9 +867,9 @@
       }
     },
     "setprototypeof": {
-      "version": "1.1.0",
-      "from": "setprototypeof@1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+      "version": "1.1.1",
+      "from": "setprototypeof@1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz"
     },
     "shelljs": {
       "version": "0.8.3",
@@ -1025,6 +1025,11 @@
       "version": "0.1.4",
       "from": "to-array@0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "from": "toidentifier@1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz"
     },
     "transformers": {
       "version": "2.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -7,20 +7,20 @@
     "test": "jshint app.js */*.js"
   },
   "dependencies": {
+    "ansi-to-html": "~0.6.9",
     "body-parser": "^1.13.3",
     "cookie-parser": "~1.4.3",
-    "shelljs": "^0.8.3",
     "express": "~4.13.3",
     "jade": "~1.11.0",
-    "morgan": "~1.6.1",
+    "morgan": "^1.9.1",
     "mysql": "^2.9.0",
     "nconf": "^0.8.2",
+    "q": "~1.4.1",
     "serve-favicon": "~2.3.0",
+    "shelljs": "^0.8.3",
     "simple-ssh": "^0.8.6",
     "socket.io": "^1.3.7",
-    "yamljs": "^0.2.4",
-    "q": "~1.4.1",
-    "ansi-to-html": "~0.6.9"
+    "yamljs": "^0.2.4"
   },
   "devDependencies": {
     "jshint": "~2.9.2"

--- a/app/routes/wizard.js
+++ b/app/routes/wizard.js
@@ -1,6 +1,5 @@
 var express = require('express');
 var router = express.Router();
-var sys = require('sys');
 var exec = require('child_process').exec;
 var shelljs = require('shelljs');
 var fs = require('fs');


### PR DESCRIPTION
Upgraded morgan nodejs package to newer version because of a
vulnerability.
Removed unused reference on "sys".

Resolves PROD-1929

ChangeLog:
* [FIX] - Upgraded morgan nodejs package